### PR TITLE
feat: create /ping/count route

### DIFF
--- a/src/c14_ping/api/routes/ping.py
+++ b/src/c14_ping/api/routes/ping.py
@@ -8,15 +8,19 @@ from c14_ping.schemas.ping_response import PingResponse
 
 router = APIRouter(prefix='/ping')
 
+global count_var
+count_var = 0
 
 @router.get('', response_model=PingResponse, status_code=status.HTTP_200_OK)
 async def ping():
     print("Pingou!")
+    global count_var
+    count_var += 1
 
     async def fire_and_forget():
         async with httpx.AsyncClient() as client:
             try:
-                await client.get("http://192.168.209.219:3000/pong")
+                await client.get("http://192.168.209.154:3000/pong")
             except Exception as e:
                 print("Erro na chamada fire-and-forget:", e)
 
@@ -24,3 +28,8 @@ async def ping():
     asyncio.create_task(fire_and_forget())
 
     return PingResponse()
+
+@router.get('/count', status_code=status.HTTP_200_OK)
+def count():
+    global count_var
+    return count_var


### PR DESCRIPTION
This pull request introduces a new feature to track and expose the number of times the `/ping` endpoint has been called, along with a minor update to the fire-and-forget HTTP request target.

**New endpoint and state tracking:**

* Added a global variable `count_var` to track the number of times the `/ping` endpoint is accessed. (`src/c14_ping/api/routes/ping.py`)
* Incremented `count_var` each time the `/ping` endpoint is called. (`src/c14_ping/api/routes/ping.py`)
* Introduced a new `/count` endpoint that returns the current value of `count_var`. (`src/c14_ping/api/routes/ping.py`)